### PR TITLE
Fix link to documentation references

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [Documentation references](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
This pull request makes a small correction to the documentation sidebar by fixing a broken link to the documentation references page. The filename in the link was updated to match the correct file name.